### PR TITLE
Optional API key and user ID

### DIFF
--- a/src/motion.ts
+++ b/src/motion.ts
@@ -221,8 +221,8 @@ export class Motion {
 
 export interface MotionOptions {
   baseUrl?: string;
-  userId: string;
-  apiKey: string;
+  userId?: string;
+  apiKey?: string;
   requestLimiter?: RateLimiterAbstract;
   overrunLimiter?: RateLimiterAbstract;
   maxQueueSize?: number;


### PR DESCRIPTION
the user ID and API key can be omitted from the constructor, if we can get them from the environment variables instead.